### PR TITLE
Use default postgres port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: assessor
       POSTGRES_PASSWORD: assessor
     ports:
-      - 54321:5432
+      - 5432:5432
   elasticsearch1:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.5.0
     container_name: elasticsearch1


### PR DESCRIPTION
It makes sense to keep the default port for Postgres.  This also matches the config for the spider 
https://github.com/codefornola/assessor-scraper/blob/master/scraper/settings.py#L81